### PR TITLE
HA 0.110

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
 )
 
 
-from homeassistant.components.media_player import MediaPlayerDevice, PLATFORM_SCHEMA
+from homeassistant.components.media_player import MediaPlayerEntity, PLATFORM_SCHEMA
 from homeassistant.components.media_player.const import (
     SUPPORT_SELECT_SOURCE,
     SUPPORT_TURN_OFF,
@@ -87,7 +87,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
 
 
-class PioneerDevice(MediaPlayerDevice):
+class PioneerDevice(MediaPlayerEntity):
     """Representation of a Pioneer device."""
 
     def __init__(self, hass, name, host, port, timeout, sources):


### PR DESCRIPTION
Fixed warning in HA log files:
2020-05-27 23:31:41 WARNING (MainThread) [homeassistant.components.media_player] MediaPlayerDevice is deprecated, modify PioneerDevice to extend MediaPlayerEntity